### PR TITLE
Fixed inconsistent sampling and added poller with condvar for better input message passing

### DIFF
--- a/client/src/event_loop.rs
+++ b/client/src/event_loop.rs
@@ -1,7 +1,7 @@
 use crate::inputs::Input;
 use crate::State;
 use common::core::states::GameState;
-use log::{debug, info, warn};
+use log::{debug, warn};
 use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use winit::platform::run_return::EventLoopExtRunReturn;
@@ -11,21 +11,9 @@ use winit::{
     window::WindowBuilder,
 };
 
-#[derive(Debug)]
-pub struct UserInput {
-    pub(crate) client_id: u8,
-    pub input: Input,
-}
-
-impl UserInput {
-    pub fn new(client_id: u8, input: Input) -> UserInput {
-        UserInput { client_id, input }
-    }
-}
-
 pub struct PlayerLoop {
     // commands is a channel that receives commands from the clients (multi-producer, single-consumer)
-    inputs: Sender<UserInput>,
+    inputs: Sender<Input>,
 
     game_state: Arc<Mutex<GameState>>,
 
@@ -37,11 +25,7 @@ impl PlayerLoop {
     /// Creates a new PlayerLoop.
     /// # Arguments
     /// * `commands` - a channel that receives commands from the clients (multi-producer, single-consumer)
-    pub fn new(
-        commands: Sender<UserInput>,
-        game_state: Arc<Mutex<GameState>>,
-        id: u8,
-    ) -> PlayerLoop {
+    pub fn new(commands: Sender<Input>, game_state: Arc<Mutex<GameState>>, id: u8) -> PlayerLoop {
         PlayerLoop {
             inputs: commands,
             game_state,
@@ -63,99 +47,101 @@ impl PlayerLoop {
         //To check
         let mut last_render_time = instant::Instant::now();
 
-        event_loop.run_return(move |event, _, control_flow| match event {
-            Event::WindowEvent {
-                ref event,
-                window_id,
-            } if window_id == state.window.id() => {
-                if !state.input(event) {
-                    match event {
-                        WindowEvent::CloseRequested
-                        | WindowEvent::KeyboardInput {
-                            input:
-                            KeyboardInput {
-                                state: ElementState::Pressed,
-                                virtual_keycode: Some(VirtualKeyCode::Escape),
+        event_loop.run_return(move |event, _, control_flow| {
+            control_flow.set_poll();
+            match event {
+                Event::WindowEvent {
+                    ref event,
+                    window_id,
+                } if window_id == state.window.id() => {
+                    if !state.input(event) {
+                        match event {
+                            WindowEvent::CloseRequested
+                            | WindowEvent::KeyboardInput {
+                                input:
+                                KeyboardInput {
+                                    state: ElementState::Pressed,
+                                    virtual_keycode: Some(VirtualKeyCode::Escape),
+                                    ..
+                                },
                                 ..
-                            },
-                            ..
-                        } => *control_flow = ControlFlow::Exit,
-                        WindowEvent::KeyboardInput { input, .. } => {
-                            info!("Keyboard input: {:?}", input);
-                            match self
-                                .inputs
-                                .send(UserInput::new(self.client_id, Input::Keyboard(*input)))
-                            {
-                                Ok(_) => {}
-                                Err(e) => {
-                                    warn!("Error sending input: {:?}", e);
+                            } => *control_flow = ControlFlow::Exit,
+                            WindowEvent::KeyboardInput { input, .. } => {
+                                match self
+                                    .inputs
+                                    .send(Input::Keyboard(*input))
+                                {
+                                    Ok(_) => {}
+                                    Err(e) => {
+                                        warn!("Error sending input: {:?}", e);
+                                    }
                                 }
                             }
+                            WindowEvent::Resized(physical_size) => {
+                                state.resize(*physical_size);
+                            }
+                            WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
+                                // new_inner_size is &&mut so we have to dereference it twice
+                                state.resize(**new_inner_size);
+                            }
+                            _ => {}
                         }
-                        WindowEvent::Resized(physical_size) => {
-                            state.resize(*physical_size);
-                        }
-                        WindowEvent::ScaleFactorChanged { new_inner_size, .. } => {
-                            // new_inner_size is &&mut so we have to dereference it twice
-                            state.resize(**new_inner_size);
-                        }
-                        _ => {}
                     }
                 }
-            }
-            // event
-            Event::DeviceEvent {
-                event: DeviceEvent::MouseMotion{ delta, },
-                .. // We're not using device_id currently
-            } => {
-                state.player_controller.process_mouse(delta.0, delta.1)
-            }
-            Event::DeviceEvent { ref event, .. } => match event {
-                DeviceEvent::MouseWheel { .. }
-                | DeviceEvent::Button { .. } => {
-                    let output_event = event.clone();
-                    match self
-                        .inputs
-                        .send(UserInput::new(self.client_id, Input::Mouse(output_event)))
-                    {
-                        Ok(_) => {}
-                        Err(e) => {
-                            debug!("Error sending input: {:?}", e);
+                // event
+                Event::DeviceEvent {
+                    event: DeviceEvent::MouseMotion{ delta, },
+                    .. // We're not using device_id currently
+                } => {
+                    state.player_controller.process_mouse(delta.0, delta.1)
+                }
+                Event::DeviceEvent { ref event, .. } => match event {
+                    DeviceEvent::MouseWheel { .. }
+                    | DeviceEvent::Button { .. } => {
+                        let output_event = event.clone();
+                        match self
+                            .inputs
+                            .send(Input::Mouse(output_event))
+                        {
+                            Ok(_) => {}
+                            Err(e) => {
+                                debug!("Error sending input: {:?}", e);
+                            }
                         }
                     }
+                    _ => {}
+                },
+                // graphics
+                Event::RedrawRequested(window_id) if window_id == state.window().id() => {
+                    // To check
+                    let now = instant::Instant::now();
+                    let dt = now - last_render_time;
+                    last_render_time = now;
+
+                    state.update(self.game_state.clone(), dt);
+
+                    // send camera position to input processor
+                    self.inputs.send(Input::Camera {
+                        forward: state.camera_state.camera.forward()
+                    }).unwrap();
+
+                    match state.render() {
+                        Ok(_) => {}
+                        // Reconfigure the surface if lost
+                        Err(wgpu::SurfaceError::Lost) => state.resize(state.size),
+                        // The system is out of memory, we should probably quit
+                        Err(wgpu::SurfaceError::OutOfMemory) => *control_flow = ControlFlow::Exit,
+                        // All other errors (Outdated, Timeout) should be resolved by the next frame
+                        Err(e) => eprintln!("{:?}", e),
+                    }
+                }
+                Event::MainEventsCleared => {
+                    // RedrawRequested will only trigger once, unless we manually
+                    // request it.
+                    state.window().request_redraw();
                 }
                 _ => {}
-            },
-            // graphics
-            Event::RedrawRequested(window_id) if window_id == state.window().id() => {
-                // To check 
-                let now = instant::Instant::now();
-                let dt = now - last_render_time;
-                last_render_time = now;
-
-                state.update(self.game_state.clone(), dt);
-
-                // send camera position to input processor
-                self.inputs.send(UserInput::new(self.client_id, Input::Camera {
-                    forward: state.camera_state.camera.forward()
-                })).unwrap();
-
-                match state.render() {
-                    Ok(_) => {}
-                    // Reconfigure the surface if lost
-                    Err(wgpu::SurfaceError::Lost) => state.resize(state.size),
-                    // The system is out of memory, we should probably quit
-                    Err(wgpu::SurfaceError::OutOfMemory) => *control_flow = ControlFlow::Exit,
-                    // All other errors (Outdated, Timeout) should be resolved by the next frame
-                    Err(e) => eprintln!("{:?}", e),
-                }
             }
-            Event::MainEventsCleared => {
-                // RedrawRequested will only trigger once, unless we manually
-                // request it.
-                state.window().request_redraw();
-            }
-            _ => {}
         });
     }
 }

--- a/client/src/inputs/handlers.rs
+++ b/client/src/inputs/handlers.rs
@@ -2,16 +2,15 @@ use crate::inputs::ButtonState;
 use common::communication::commons::*;
 use common::communication::message::*;
 
-
-use common::core::command::{Command};
+use common::core::command::Command;
 use glm::Vec3;
-use log::{error, info};
+use log::{debug, error, info};
 use queues::{IsQueue, Queue};
 
 use std::time::Instant;
 use winit::event::{DeviceEvent, MouseScrollDelta, VirtualKeyCode};
 
-pub enum GameKey {
+pub enum GameKeyKind {
     Pressable,
     Holdable,
     PressRelease,
@@ -29,29 +28,23 @@ pub fn handle_camera_update(camera_forward: Vec3, protocol: &mut Protocol, clien
 }
 
 pub fn handle_game_key_input(
-    game_key: GameKey,
+    game_key_kind: GameKeyKind,
     command: Command,
-    keycode: &VirtualKeyCode,
     button_state: &ButtonState,
     protocol: &mut Protocol,
     client_id: u8,
 ) -> bool {
-    match game_key {
-        GameKey::Pressable => {
-            handle_pressable_key(command, keycode, button_state, protocol, client_id)
-        }
-        GameKey::Holdable => {
-            handle_holdable_key(command, keycode, button_state, protocol, client_id)
-        }
-        GameKey::PressRelease => {
-            handle_press_release_key(command, keycode, button_state, protocol, client_id)
+    match game_key_kind {
+        GameKeyKind::Pressable => handle_pressable_key(command, button_state, protocol, client_id),
+        GameKeyKind::Holdable => handle_holdable_key(command, button_state, protocol, client_id),
+        GameKeyKind::PressRelease => {
+            handle_press_release_key(command, button_state, protocol, client_id)
         }
     }
 }
 
 fn handle_pressable_key(
     command: Command,
-    _keycode: &VirtualKeyCode,
     button_state: &ButtonState,
     protocol: &mut Protocol,
     client_id: u8,
@@ -64,7 +57,7 @@ fn handle_pressable_key(
                 Payload::Command(command.clone()),
             );
             protocol.send_message(&message).expect("send message fails");
-            info!("Sent command: {:?}", command);
+            debug!("Sent command: {:?}", command);
         }
         // if released, remove from the held map
         ButtonState::Released => return false,
@@ -76,7 +69,6 @@ fn handle_pressable_key(
 
 fn handle_holdable_key(
     command: Command,
-    _keycode: &VirtualKeyCode,
     button_state: &ButtonState,
     protocol: &mut Protocol,
     client_id: u8,
@@ -89,7 +81,7 @@ fn handle_holdable_key(
                 Payload::Command(command.clone()),
             );
             protocol.send_message(&message).expect("send message fails");
-            info!("Sent command: {:?}", command);
+            debug!("Sent command: {:?}", command);
         }
         // if released, remove from the held map
         ButtonState::Released => {
@@ -102,7 +94,6 @@ fn handle_holdable_key(
 
 fn handle_press_release_key(
     command: Command,
-    _keycode: &VirtualKeyCode,
     button_state: &ButtonState,
     protocol: &mut Protocol,
     client_id: u8,
@@ -115,7 +106,7 @@ fn handle_press_release_key(
                 Payload::Command(command.clone()),
             );
             protocol.send_message(&message).expect("send message fails");
-            info!("Sent command: {:?}", command);
+            debug!("Sent command: {:?}", command);
         }
         // if released, do the corresponding action and then remove from the held map
         ButtonState::Released => {
@@ -124,7 +115,7 @@ fn handle_press_release_key(
                 Payload::Command(command.clone()),
             );
             protocol.send_message(&message).expect("send message fails");
-            info!("Sent command: {:?}", command);
+            debug!("Sent command: {:?}", command);
             return false;
         }
         _ => {}

--- a/client/src/inputs/handlers.rs
+++ b/client/src/inputs/handlers.rs
@@ -1,14 +1,15 @@
 use crate::inputs::ButtonState;
 use common::communication::commons::*;
 use common::communication::message::*;
-use common::core::command::Command::{Action, Jump, Spawn};
-use common::core::command::GameAction::Attack;
-use common::core::command::{Command, MoveDirection};
+
+
+use common::core::command::{Command};
+use glm::Vec3;
 use log::{error, info};
 use queues::{IsQueue, Queue};
-use std::collections::HashMap;
+
 use std::time::Instant;
-use winit::event::{DeviceEvent, ElementState, KeyboardInput, MouseScrollDelta, VirtualKeyCode};
+use winit::event::{DeviceEvent, MouseScrollDelta, VirtualKeyCode};
 
 pub enum GameKey {
     Pressable,
@@ -16,98 +17,48 @@ pub enum GameKey {
     PressRelease,
 }
 
-pub fn handle_keyboard_input(
-    held_map: &mut HashMap<VirtualKeyCode, ButtonState>,
-    input: KeyboardInput,
-    protocol: &mut Protocol,
-    client_id: u8,
-) {
-    // change state
-    if let Some(keycode) = input.virtual_keycode {
-        update_held_map(held_map, keycode, input.state);
-        // map keyboard input to command
-        let key_command: Option<(GameKey, Command)> = match input.virtual_keycode {
-            // match Holdable keys
-            Some(VirtualKeyCode::W) => {
-                Some((GameKey::Holdable, Command::Move(MoveDirection::Forward)))
-            }
-            Some(VirtualKeyCode::A) => {
-                Some((GameKey::Holdable, Command::Move(MoveDirection::Left)))
-            }
-            Some(VirtualKeyCode::S) => {
-                Some((GameKey::Holdable, Command::Move(MoveDirection::Backward)))
-            }
-            Some(VirtualKeyCode::D) => {
-                Some((GameKey::Holdable, Command::Move(MoveDirection::Right)))
-            }
-            // match Pressable keys
-            Some(VirtualKeyCode::Space) => Some((GameKey::Pressable, Jump)),
-            // match PressRelease keys
-            Some(VirtualKeyCode::LShift) => Some((GameKey::PressRelease, Spawn)),
-            Some(VirtualKeyCode::F) => Some((GameKey::PressRelease, Action(Attack))),
-            _ => None,
-        };
-
-        if let Some((game_key, command)) = key_command {
-            handle_game_key_input(game_key, command, keycode, held_map, protocol, client_id);
-        } else {
-            info!("No game key or action to handle");
-        }
-    }
-}
-
-pub fn update_held_map(
-    held_map: &mut HashMap<VirtualKeyCode, ButtonState>,
-    keycode: VirtualKeyCode,
-    ele_state: ElementState,
-) {
-    use winit::event::ElementState as es;
-    use ButtonState as bs;
-    let next_state = if let Some(state) = held_map.get(&keycode) {
-        match (state, ele_state) {
-            (bs::Pressed, es::Pressed) => ButtonState::Held, // pressed -> (pressed) -> held
-            (bs::Released, es::Pressed) => ButtonState::Pressed, // released -> (pressed) -> pressed
-            (_, es::Released) => ButtonState::Released, // some -> (released) -> released
-            (bs, _) => bs.clone(), // same state
-        }
-    } else {
-        ButtonState::Pressed
-    };
-    held_map.insert(keycode, next_state);
+pub fn handle_camera_update(camera_forward: Vec3, protocol: &mut Protocol, client_id: u8) {
+    let message: Message = Message::new(
+        HostRole::Client(client_id),
+        Payload::Command(Command::UpdateCamera {
+            forward: camera_forward,
+        }),
+    );
+    protocol.send_message(&message).expect("send message fails");
+    // info!("Sent camera update");
 }
 
 pub fn handle_game_key_input(
     game_key: GameKey,
     command: Command,
-    keycode: VirtualKeyCode,
-    held_map: &mut HashMap<VirtualKeyCode, ButtonState>,
+    keycode: &VirtualKeyCode,
+    button_state: &ButtonState,
     protocol: &mut Protocol,
     client_id: u8,
-) {
+) -> bool {
     match game_key {
         GameKey::Pressable => {
-            handle_pressable_key(command, keycode, held_map, protocol, client_id);
+            handle_pressable_key(command, keycode, button_state, protocol, client_id)
         }
         GameKey::Holdable => {
-            handle_holdable_key(command, keycode, held_map, protocol, client_id);
+            handle_holdable_key(command, keycode, button_state, protocol, client_id)
         }
         GameKey::PressRelease => {
-            handle_press_release_key(command, keycode, held_map, protocol, client_id);
+            handle_press_release_key(command, keycode, button_state, protocol, client_id)
         }
     }
 }
 
 fn handle_pressable_key(
     command: Command,
-    keycode: VirtualKeyCode,
-    held_map: &mut HashMap<VirtualKeyCode, ButtonState>,
+    _keycode: &VirtualKeyCode,
+    button_state: &ButtonState,
     protocol: &mut Protocol,
     client_id: u8,
-) {
-    info!("Received game key: {:?}", command);
-    match held_map.get(&keycode) {
+) -> bool {
+    match button_state {
         // if pressed, send command
-        Some(ButtonState::Pressed) => {
+        ButtonState::Pressed => {
             let message: Message = Message::new(
                 HostRole::Client(client_id),
                 Payload::Command(command.clone()),
@@ -116,25 +67,23 @@ fn handle_pressable_key(
             info!("Sent command: {:?}", command);
         }
         // if released, remove from the held map
-        Some(ButtonState::Released) => {
-            held_map.remove(&keycode);
-        }
+        ButtonState::Released => return false,
         // if held or others, don't do nothing
         _ => {}
-    }
+    };
+    true
 }
 
 fn handle_holdable_key(
     command: Command,
-    keycode: VirtualKeyCode,
-    held_map: &mut HashMap<VirtualKeyCode, ButtonState>,
+    _keycode: &VirtualKeyCode,
+    button_state: &ButtonState,
     protocol: &mut Protocol,
     client_id: u8,
-) {
-    info!("Received game key: {:?}", command);
-    match held_map.get(&keycode) {
+) -> bool {
+    match button_state {
         // if pressed or held, keep sending command
-        Some(ButtonState::Pressed) | Some(ButtonState::Held) => {
+        ButtonState::Pressed | ButtonState::Held => {
             let message: Message = Message::new(
                 HostRole::Client(client_id),
                 Payload::Command(command.clone()),
@@ -143,24 +92,24 @@ fn handle_holdable_key(
             info!("Sent command: {:?}", command);
         }
         // if released, remove from the held map
-        Some(ButtonState::Released) => {
-            held_map.remove(&keycode);
+        ButtonState::Released => {
+            return false;
         }
         _ => {}
     }
+    true
 }
 
 fn handle_press_release_key(
     command: Command,
-    keycode: VirtualKeyCode,
-    held_map: &mut HashMap<VirtualKeyCode, ButtonState>,
+    _keycode: &VirtualKeyCode,
+    button_state: &ButtonState,
     protocol: &mut Protocol,
     client_id: u8,
-) {
-    info!("Received game key: {:?}", command);
-    match held_map.get(&keycode) {
+) -> bool {
+    match button_state {
         // if pressed or held, keep sending command
-        Some(ButtonState::Pressed) | Some(ButtonState::Held) => {
+        ButtonState::Pressed | ButtonState::Held => {
             let message: Message = Message::new(
                 HostRole::Client(client_id),
                 Payload::Command(command.clone()),
@@ -169,17 +118,18 @@ fn handle_press_release_key(
             info!("Sent command: {:?}", command);
         }
         // if released, do the corresponding action and then remove from the held map
-        Some(ButtonState::Released) => {
+        ButtonState::Released => {
             let message: Message = Message::new(
                 HostRole::Client(client_id),
                 Payload::Command(command.clone()),
             );
             protocol.send_message(&message).expect("send message fails");
             info!("Sent command: {:?}", command);
-            held_map.remove(&keycode);
+            return false;
         }
         _ => {}
-    }
+    };
+    true
 }
 
 /// ***************************************** Mouse *********************************************///

--- a/client/src/inputs/mod.rs
+++ b/client/src/inputs/mod.rs
@@ -1,14 +1,17 @@
-use crate::event_loop::UserInput;
-use common::communication::commons::{Protocol, DEFAULT_MOUSE_MOVEMENT_INTERVAL};
-use common::communication::message::{HostRole, Message, Payload};
-use common::core::command::Command;
+use crate::inputs::handlers::{handle_camera_update, handle_game_key_input, GameKey};
+use common::communication::commons::{Protocol};
+use common::core::command::Command::{Action, Jump, Spawn};
+use common::core::command::GameAction::Attack;
+use common::core::command::{Command, MoveDirection};
 use glm::Vec3;
-use log::{error, info};
-use queues::{IsQueue, Queue};
+use log::debug;
+
 use std::collections::HashMap;
 use std::sync::mpsc::Receiver;
-use std::time::{Duration, Instant};
-use winit::event::{DeviceEvent, KeyboardInput, MouseScrollDelta, VirtualKeyCode};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread;
+use std::time::Duration;
+use winit::event::{DeviceEvent, ElementState, KeyboardInput, VirtualKeyCode};
 
 pub mod handlers;
 
@@ -26,127 +29,167 @@ pub enum ButtonState {
     Released,
 }
 
-pub struct InputProcessor {
+/// Input polling interval
+pub const POLLER_INTERVAL: Duration = Duration::from_millis(60);
+
+pub struct InputEventProcessor {
     protocol: Protocol,
     client_id: u8,
-    rx: Receiver<UserInput>,
+    rx: Receiver<Input>,
+    button_states: Arc<Mutex<HashMap<VirtualKeyCode, ButtonState>>>,
+    camera_forward: Arc<Mutex<Vec3>>,
+    poller_signal: Arc<(Mutex<bool>, Condvar)>,
 }
 
-impl InputProcessor {
-    pub fn new(protocol: Protocol, client_id: u8, rx: Receiver<UserInput>) -> Self {
-        InputProcessor {
+impl InputEventProcessor {
+    pub fn new(protocol: Protocol, client_id: u8, rx: Receiver<Input>) -> Self {
+        InputEventProcessor {
             protocol,
             client_id,
             rx,
+            button_states: Arc::new(Mutex::new(HashMap::new())),
+            camera_forward: Arc::new(Mutex::new(Default::default())),
+            poller_signal: Arc::new((Mutex::new(true), Condvar::new())),
         }
     }
 
-    pub fn run(&mut self) {
-        let mut held_map: HashMap<VirtualKeyCode, ButtonState> = HashMap::new();
+    // TODO: make this more maintainable
+    pub fn map_key(virtual_keycode: VirtualKeyCode) -> Option<(GameKey, Command)> {
+        match virtual_keycode {
+            // match Holdable keys
+            VirtualKeyCode::W => Some((GameKey::Holdable, Command::Move(MoveDirection::Forward))),
+            VirtualKeyCode::A => Some((GameKey::Holdable, Command::Move(MoveDirection::Left))),
+            VirtualKeyCode::S => Some((GameKey::Holdable, Command::Move(MoveDirection::Backward))),
+            VirtualKeyCode::D => Some((GameKey::Holdable, Command::Move(MoveDirection::Right))),
+            // match Pressable keys
+            VirtualKeyCode::Space => Some((GameKey::Pressable, Jump)),
+            // match PressRelease keys
+            VirtualKeyCode::LShift => Some((GameKey::PressRelease, Spawn)),
+            VirtualKeyCode::F => Some((GameKey::PressRelease, Action(Attack))),
+            _ => None,
+        }
+    }
 
-        let mut mouse_motion_buf = Queue::new();
-        let mut mouse_wheel_buf = Queue::new();
-        let mut sample_start_time = Instant::now();
+    pub fn start_poller(&self) {
+        let mut protocol = self.protocol.try_clone().unwrap();
+        let client_id = self.client_id;
+        let button_states = Arc::clone(&self.button_states);
+        let camera_forward = Arc::clone(&self.camera_forward);
+        let poller_signal = Arc::clone(&self.poller_signal);
 
-        let mut last_camera_update_time = Instant::now();
+        thread::spawn(move || {
+            let (lock, cvar) = &*poller_signal;
+            loop {
+                // wait for signal (asap event) or timeout
+                let signal = lock.lock().unwrap();
+                let (mut signal, res) = cvar.wait_timeout(signal, POLLER_INTERVAL).unwrap();
 
-        while let Ok(user_input) = self.rx.recv() {
-            info!("Received input: {:?}", user_input);
-            match user_input.input {
-                Input::Keyboard(input) => {
-                    handlers::handle_keyboard_input(
-                        &mut held_map,
-                        input,
-                        &mut self.protocol,
-                        self.client_id,
-                    );
+                if res.timed_out() {
+                    debug!("poller timed out");
+                    *signal = false;
+                } else {
+                    debug!("poller received signal");
                 }
-                Input::Mouse(input) => {
-                    handlers::handle_mouse_input(
-                        input,
-                        &mut mouse_motion_buf,
-                        &mut mouse_wheel_buf,
+
+                let mut button_states = button_states.lock().unwrap();
+                let camera_forward = camera_forward.lock().unwrap();
+
+                button_states.retain(|key, state| {
+                    if let Some((key_type, command)) = Self::map_key(*key) {
+                        let retain = handle_game_key_input(
+                            key_type,
+                            command,
+                            key,
+                            state,
+                            &mut protocol,
+                            client_id,
+                        );
+
+                        // naturally progress the button state
+                        *state = Self::internal_next_state(state.clone());
+
+                        retain
+                    } else {
+                        false
+                    }
+                });
+
+                // send camera update
+                // TODO: send camera update only when the camera has moved
+                handle_camera_update(*camera_forward, &mut protocol, client_id);
+            }
+        });
+    }
+
+    /// listen to input events from the event loop and update the states when necessary
+    pub fn listen(&mut self) {
+        while let Ok(input) = self.rx.recv() {
+            match input {
+                Input::Keyboard(KeyboardInput {
+                    virtual_keycode: Some(key_code),
+                    state,
+                    ..
+                }) => {
+                    // on receiving keyboard input, update the button state
+                    self.update_button_state(key_code, state);
+                    debug!(
+                        "processed_keyboard_input: {:?}, button_states: {:?}",
+                        key_code,
+                        self.button_states.lock().unwrap()
                     );
+
+                    // Signal the poller to send data as soon as possible
+                    // Should be only for "Pressable" keys since otherwise the sampling rate will be inconsistent
+                    // This optimization will be significant if we decide to use a longer polling interval (e.g. > 100ms) to save bandwidth
+                    if let Some((GameKey::Pressable, _)) = Self::map_key(key_code) {
+                        let (lock, cvar) = &*self.poller_signal;
+                        let mut signal = lock.lock().unwrap();
+                        *signal = true;
+                        cvar.notify_one(); // notify the poller to send data immediately
+                    }
                 }
-                // receive camera update and it is past the interval since last update
-                Input::Camera { forward }
-                    if last_camera_update_time.elapsed() >= Duration::from_millis(100) =>
-                {
-                    self.protocol
-                        .send_message(&Message::new(
-                            HostRole::Client(self.client_id),
-                            Payload::Command(Command::UpdateCamera { forward }),
-                        ))
-                        .expect("send message fails");
-                    last_camera_update_time = Instant::now();
+
+                // receive camera update
+                Input::Camera { forward } => {
+                    let mut camera_forward = self.camera_forward.lock().unwrap();
+                    *camera_forward = forward;
                 }
                 _ => {}
             }
-
-            // Should always check? buffered mouse inputs cannot be good right?
-            // ideally runs in a always checking thread
-            if !(mouse_motion_buf.size() == 0 && mouse_wheel_buf.size() == 0)
-                && sample_start_time.elapsed()
-                    >= Duration::from_millis(DEFAULT_MOUSE_MOVEMENT_INTERVAL)
-            {
-                handlers::send_mouse_input(
-                    &mut mouse_motion_buf,
-                    &mut mouse_wheel_buf,
-                    &mut sample_start_time,
-                    &mut self.protocol,
-                    self.client_id,
-                );
-
-                if sample_start_time.elapsed()
-                    < Duration::from_millis(DEFAULT_MOUSE_MOVEMENT_INTERVAL)
-                {
-                    continue;
-                }
-
-                let mut mm_tot_dx = 0.0;
-                let mut mm_tot_dy = 0.0;
-                let mut mw_tot_line_dx = 0.0;
-                let mut mw_tot_line_dy = 0.0;
-                let mut mw_tot_pixel_dx = 0.0;
-                let mut mw_tot_pixel_dy = 0.0;
-
-                let n = mouse_motion_buf.size();
-                for _ in 1..n {
-                    let mm_event = mouse_motion_buf.remove().unwrap();
-                    match mm_event {
-                        DeviceEvent::MouseMotion { delta } => {
-                            let (dx, dy) = delta;
-                            mm_tot_dx += dx;
-                            mm_tot_dy += dy;
-                        }
-                        _ => {
-                            error!("non-mouse-motion in mouse motion buffer \n")
-                        }
-                    }
-                    let mw_event = mouse_wheel_buf.remove().unwrap();
-                    if let DeviceEvent::MouseWheel { delta } = mw_event {
-                        match delta {
-                            MouseScrollDelta::LineDelta(dx, dy) => {
-                                mw_tot_line_dx += dx;
-                                mw_tot_line_dy += dy;
-                            }
-                            MouseScrollDelta::PixelDelta(pixel_delta) => {
-                                mw_tot_pixel_dx += pixel_delta.x;
-                                mw_tot_pixel_dy += pixel_delta.y;
-                            }
-                        }
-                    }
-                }
-                sample_start_time = Instant::now();
-
-                self.protocol
-                    .send_message(&Message::new(
-                        HostRole::Client(self.client_id),
-                        Payload::Command(Command::Turn(Default::default())),
-                    ))
-                    .expect("send message fails");
-                info!("Sent command: {:?}", "Turn");
-            }
         }
+    }
+
+    /// updates the button state based on the input state (`ele_state`)
+    fn next_state(es: ElementState, bs: ButtonState) -> ButtonState {
+        use winit::event::ElementState as es;
+        use ButtonState as bs;
+
+        match (bs, es) {
+            (bs::Pressed, es::Pressed) => ButtonState::Held, // pressed -> (pressed) -> held
+            (bs::Released, es::Pressed) => ButtonState::Pressed, // released -> (pressed) -> pressed
+            (_, es::Released) => ButtonState::Released,      // some -> (released) -> released
+            (bs, _) => bs,                                   // same state
+        }
+    }
+
+    /// models the natural progression of button states between sample ticks when there's no input
+    fn internal_next_state(bs: ButtonState) -> ButtonState {
+        use ButtonState as bs;
+
+        match bs {
+            bs::Pressed => bs::Held,
+            other => other,
+        }
+    }
+
+    pub fn update_button_state(&mut self, keycode: VirtualKeyCode, ele_state: ElementState) {
+        let mut button_states = self.button_states.lock().unwrap();
+
+        let next_state = if let Some(state) = button_states.get(&keycode) {
+            Self::next_state(ele_state, state.clone())
+        } else {
+            ButtonState::Pressed
+        };
+        button_states.insert(keycode, next_state);
     }
 }

--- a/client/src/inputs/mod.rs
+++ b/client/src/inputs/mod.rs
@@ -1,5 +1,5 @@
-use crate::inputs::handlers::{handle_camera_update, handle_game_key_input, GameKey};
-use common::communication::commons::{Protocol};
+use crate::inputs::handlers::{handle_camera_update, handle_game_key_input, GameKeyKind};
+use common::communication::commons::Protocol;
 use common::core::command::Command::{Action, Jump, Spawn};
 use common::core::command::GameAction::Attack;
 use common::core::command::{Command, MoveDirection};
@@ -54,18 +54,18 @@ impl InputEventProcessor {
     }
 
     // TODO: make this more maintainable
-    pub fn map_key(virtual_keycode: VirtualKeyCode) -> Option<(GameKey, Command)> {
+    pub fn map_key(virtual_keycode: VirtualKeyCode) -> Option<(GameKeyKind, Command)> {
         match virtual_keycode {
             // match Holdable keys
-            VirtualKeyCode::W => Some((GameKey::Holdable, Command::Move(MoveDirection::Forward))),
-            VirtualKeyCode::A => Some((GameKey::Holdable, Command::Move(MoveDirection::Left))),
-            VirtualKeyCode::S => Some((GameKey::Holdable, Command::Move(MoveDirection::Backward))),
-            VirtualKeyCode::D => Some((GameKey::Holdable, Command::Move(MoveDirection::Right))),
+            VirtualKeyCode::W => Some((GameKeyKind::Holdable, Command::Move(MoveDirection::Forward))),
+            VirtualKeyCode::A => Some((GameKeyKind::Holdable, Command::Move(MoveDirection::Left))),
+            VirtualKeyCode::S => Some((GameKeyKind::Holdable, Command::Move(MoveDirection::Backward))),
+            VirtualKeyCode::D => Some((GameKeyKind::Holdable, Command::Move(MoveDirection::Right))),
             // match Pressable keys
-            VirtualKeyCode::Space => Some((GameKey::Pressable, Jump)),
+            VirtualKeyCode::Space => Some((GameKeyKind::Pressable, Jump)),
             // match PressRelease keys
-            VirtualKeyCode::LShift => Some((GameKey::PressRelease, Spawn)),
-            VirtualKeyCode::F => Some((GameKey::PressRelease, Action(Attack))),
+            VirtualKeyCode::LShift => Some((GameKeyKind::PressRelease, Spawn)),
+            VirtualKeyCode::F => Some((GameKeyKind::PressRelease, Action(Attack))),
             _ => None,
         }
     }
@@ -99,7 +99,6 @@ impl InputEventProcessor {
                         let retain = handle_game_key_input(
                             key_type,
                             command,
-                            key,
                             state,
                             &mut protocol,
                             client_id,
@@ -141,7 +140,7 @@ impl InputEventProcessor {
                     // Signal the poller to send data as soon as possible
                     // Should be only for "Pressable" keys since otherwise the sampling rate will be inconsistent
                     // This optimization will be significant if we decide to use a longer polling interval (e.g. > 100ms) to save bandwidth
-                    if let Some((GameKey::Pressable, _)) = Self::map_key(key_code) {
+                    if let Some((GameKeyKind::Pressable, _)) = Self::map_key(key_code) {
                         let (lock, cvar) = &*self.poller_signal;
                         let mut signal = lock.lock().unwrap();
                         *signal = true;

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -173,8 +173,8 @@ impl State {
             &queue,
             &texture_bind_group_layout,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
         let instance_vec = vec![
             instance::Instance {
                 #[rustfmt::skip]
@@ -202,8 +202,8 @@ impl State {
             &queue,
             &texture_bind_group_layout,
         )
-            .await
-            .unwrap();
+        .await
+        .unwrap();
         let cube_instance_vec = vec![instance::Instance {
             #[rustfmt::skip]
             transform: glm::mat4(

--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -5,7 +5,7 @@ use std::env;
 use log::{debug, error, info};
 use std::fs::File;
 
-use env_logger::{Builder};
+use env_logger::Builder;
 use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::sync::{mpsc, Arc, Mutex};

--- a/client/src/player.rs
+++ b/client/src/player.rs
@@ -1,6 +1,6 @@
 use common::core::states::PlayerState;
 use instant::Duration;
-use std::collections::HashMap;
+
 use std::f32::consts::FRAC_PI_2;
 use std::f32::consts::PI;
 use winit::dpi::PhysicalPosition;
@@ -68,7 +68,6 @@ pub struct PlayerController {
 
 impl PlayerController {
     pub fn new(x_sensitivity: f32, y_sensitivity: f32) -> Self {
-
         Self {
             rotate_horizontal: 0.0,
             rotate_vertical: 0.0,

--- a/common/src/core/command.rs
+++ b/common/src/core/command.rs
@@ -38,7 +38,7 @@ mod tests {
     fn test_serialize_and_deserialize_json() {
         let command = Command::Move(MoveDirection::Forward);
         let serialized = serde_json::to_string(&command).unwrap();
-        let deserialized: Command = serde_json::from_str(&serialized).unwrap();
+        let _deserialized: Command = serde_json::from_str(&serialized).unwrap();
         // assert_eq!(command, deserialized);
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -19,7 +19,7 @@ mod client_handler;
 use client_handler::ClientHandler;
 
 pub static CLIENT_ID_ASSIGNER: AtomicU8 = AtomicU8::new(1);
-pub static SESSION_ID: Lazy<u64> = Lazy::new(|| rand::random::<u64>());
+pub static SESSION_ID: Lazy<u64> = Lazy::new(rand::random::<u64>);
 
 fn main() {
     env_logger::init();


### PR DESCRIPTION
Refactored the input system by introducing a poller which solves the inconsistent sampling rate issue. This is necessary for stable cross-platform experience and winit does not support customization on repeat delay.

The poller uses a condition variable to wait for the intervals, and it can be waken up if there are events that need to be handled immediately (like "pressable" inputs).