### PR TITLE
missing import in main branch

### DIFF
--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -9,7 +9,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{mpsc, Arc, Mutex};
 use std::{net::TcpListener, thread};
 
-use common::communication::commons::{CSE125_SERVER_ADDR};
+use common::communication::commons::{DEFAULT_SERVER_ADDR, CSE125_SERVER_ADDR};
 
 use server::executor::Executor;
 use threadpool::ThreadPool;


### PR DESCRIPTION
Imported DEFAULT_SERVER_ADDR in server/src/main.rs; couldn't compile the server code in the main branch without it even though it was part of inactive code.